### PR TITLE
Bugfix add all explicit SGX package versions

### DIFF
--- a/dockerfile/04_psw.sh
+++ b/dockerfile/04_psw.sh
@@ -3,10 +3,25 @@ curl -fsSL -O https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.ke
 cat intel-sgx-deb.key | tee /etc/apt/keyrings/intel-sgx-keyring.asc > /dev/null && \
 apt-get update && \
 apt-get install -y \
+	libsgx-ae-pce=$VERSION \
 	libsgx-enclave-common-dev=$VERSION \
+	libsgx-enclave-common=$VERSION \
+	libsgx-headers=$VERSION \
+	libsgx-launch=$VERSION \
+	libsgx-quote-ex=$VERSION \
+	libsgx-urts=$VERSION \
+	sgx-aesm-service=$VERSION \
+	libsgx-ae-id-enclave=$DCAP_VERSION \
+	libsgx-ae-qe3=$DCAP_VERSION \
+	libsgx-ae-qve=$DCAP_VERSION \
 	libsgx-dcap-ql-dev=$DCAP_VERSION \
+	libsgx-dcap-ql=$DCAP_VERSION \
 	libsgx-dcap-default-qpl-dev=$DCAP_VERSION \
-	libsgx-dcap-quote-verify-dev=$DCAP_VERSION && \
+	libsgx-dcap-default-qpl=$DCAP_VERSION \
+	libsgx-dcap-quote-verify-dev=$DCAP_VERSION \
+	libsgx-dcap-quote-verify=$DCAP_VERSION \
+	libsgx-pce-logic=$DCAP_VERSION \
+	libsgx-qe3-logic=$DCAP_VERSION && \
 mkdir /var/run/aesmd && \
 rm -rf /var/lib/apt/lists/* && \
 rm -rf /var/cache/apt/archives/*

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 # First install packages listed at https://github.com/intel/linux-sgx
 RUN apt install -y build-essential ocaml ocamlbuild automake autoconf libtool python-is-python3 libssl-dev git cmake perl
-RUN apt install -y curl software-properties-common
+RUN apt install -y curl software-properties-common bsdmainutils
 RUN rm -rf /var/lib/apt/lists/*
 
 ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/lib


### PR DESCRIPTION
I was updating the Dockerfile for the factory agent. Fixing this mistake I made earlier where all the SGX transitive dependencies were not locked to the version numbers.

Also install bsdmainutils.