### PR TITLE
add ninja-build and sccache

### DIFF
--- a/dockerfile/05_rust.sh
+++ b/dockerfile/05_rust.sh
@@ -9,5 +9,6 @@ curl 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-i
 chmod +x /root/rustup-init && \
 echo '1' | /root/rustup-init --default-toolchain ${rust_toolchain} && \
 /opt/cargo/bin/rustup component add rust-src rls rust-analysis clippy rustfmt && \
-/opt/cargo/bin/cargo --config "net.git-fetch-with-cli = true" install xargo
+/opt/cargo/bin/cargo --config "net.git-fetch-with-cli = true" install xargo && \
+rm /root/rustup-init
 ln -s /opt/rustup /root/.rustup

--- a/dockerfile/05_rust.sh
+++ b/dockerfile/05_rust.sh
@@ -1,10 +1,13 @@
 # Use net.git-fetch-with-cli to avoid OOM on arm64:
 # https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
+
+export CARGO_HOME=/opt/cargo
+export RUSTUP_HOME=/opt/rustup
+
 cd /root && \
 curl 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init' --output /root/rustup-init && \
 chmod +x /root/rustup-init && \
 echo '1' | /root/rustup-init --default-toolchain ${rust_toolchain} && \
-echo 'source /root/.cargo/env' >> /root/.bashrc && \
-/root/.cargo/bin/rustup component add rust-src rls rust-analysis clippy rustfmt && \
-/root/.cargo/bin/cargo --config "net.git-fetch-with-cli = true" install xargo && \
-rm /root/rustup-init && rm -rf /root/.cargo/registry && rm -rf /root/.cargo/git
+/opt/cargo/bin/rustup component add rust-src rls rust-analysis clippy rustfmt && \
+/opt/cargo/bin/cargo --config "net.git-fetch-with-cli = true" install xargo
+ln -s /opt/rustup /root/.rustup

--- a/dockerfile/06_sccache.sh
+++ b/dockerfile/06_sccache.sh
@@ -1,6 +1,2 @@
-# Use net.git-fetch-with-cli to avoid OOM on arm64:
-# https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
-
 export CARGO_HOME=/opt/cargo
-source /opt/cargo/env
-/opt/cargo/bin/cargo install sccache --locked
+/opt/cargo/bin/cargo --config "net.git-fetch-with-cli = true" install sccache --locked

--- a/dockerfile/06_sccache.sh
+++ b/dockerfile/06_sccache.sh
@@ -1,0 +1,6 @@
+# Use net.git-fetch-with-cli to avoid OOM on arm64:
+# https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
+
+export CARGO_HOME=/opt/cargo
+source /opt/cargo/env
+/opt/cargo/bin/cargo install sccache --locked

--- a/dockerfile/07_cleanup.sh
+++ b/dockerfile/07_cleanup.sh
@@ -1,0 +1,2 @@
+rm -rf /opt/cargo/registry
+rm -rf /opt/cargo/git

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -37,6 +37,9 @@ RUN bash /root/05_rust.sh
 ADD 06_sccache.sh /root
 RUN bash /root/06_sccache.sh
 
+ADD 07_cleanup.sh /root
+RUN bash /root/07_cleanup.sh
+
 ENV DEBIAN_FRONTEND=
 ENV CODENAME=
 ENV VERSION=

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -5,7 +5,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 # First install packages listed at https://github.com/intel/linux-sgx
 RUN apt install -y build-essential ocaml ocamlbuild automake autoconf libtool python-is-python3 libssl-dev git cmake perl
-RUN apt install -y curl software-properties-common bsdmainutils
+RUN apt install -y curl software-properties-common bsdmainutils ninja-build
+
+#sccache dependencies
+RUN apt install -y libssl-dev pkg-config
+
 RUN rm -rf /var/lib/apt/lists/*
 
 ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/lib
@@ -29,6 +33,9 @@ RUN bash /root/04_psw.sh
 ENV rust_toolchain  nightly-2022-10-21
 ADD 05_rust.sh /root
 RUN bash /root/05_rust.sh
+
+ADD 06_sccache.sh /root
+RUN bash /root/06_sccache.sh
 
 ENV DEBIAN_FRONTEND=
 ENV CODENAME=


### PR DESCRIPTION
Adds ninja-build and sccache to container.

Allow the rust compiler and toolchain to be run by any user ID inside the container. The root user doesn't need to make any changes to their entry point, because /root/.bashrc has a line to source /opt/cargo/env and /root/.rustup has been made a symlink to /opt/rustup. A non-root user does not have a $HOME directory in the container.  If running as a non-root user then: 1) set RUSTUP_HOME to /opt/rustup, 2) set CARGO_HOME to a writable directory, and 3) source /opt/cargo/env.